### PR TITLE
load DLC from ROCKBAND3 folder on PS3 for parity with RB2DX

### DIFF
--- a/_ark/config/band.dta
+++ b/_ark/config/band.dta
@@ -139,6 +139,17 @@
                "UP0006-BLUS30147_00")
             (test
                "UP0006-NPXX00360_00")))
+	 (rb3
+         (title_id
+            (live
+               "ROCKBAND3")
+            (test
+               "NPXX00500"))
+         (service_id
+            (live
+               "UP8802-BLUS30463_00")
+            (test
+               "UP0006-NPXX00500_00")))	 
       #ifdef _LRB_REGION_EU
       (rb1
          (title_id


### PR DESCRIPTION
RB2DX will load songs from the "ROCKBAND3" folder so you can install RB3toRB2 without conflicting with RB3, this ports the exact script lines from RB2DX to the LRB scripts
tested and working on RPCS3, should work on hardware PS3 (sorry 360 users)